### PR TITLE
return 'Invalid' instead of raising exception

### DIFF
--- a/cleaver/experiment.py
+++ b/cleaver/experiment.py
@@ -142,15 +142,26 @@ class VariantStat(object):
         conv_c = control.conversion_rate
         conv_a = alternative.conversion_rate
 
-        c = control.participant_count
-        a = alternative.participant_count
+        num_c = control.participant_count
+        num_a = alternative.participant_count
 
         if conv_c == 0 or conv_a == 0:
             return 0
 
-        z = conv_a - conv_c
-        s = (conv_a * (1 - conv_a)) / a + (conv_c * (1 - conv_c)) / c
-        return z / math.sqrt(s)
+        numerator = conv_a - conv_c
+
+        frac_c = (conv_c * (1 - conv_c)) / float(num_c)
+        frac_a = (conv_a * (1 - conv_a)) / float(num_a)
+
+        if frac_c + frac_a == 0:
+            # square root of 0 is 0, so no need to calculate
+            return 0
+        elif frac_c + frac_a < 0:
+            # can't take a square root of a negative number,
+            # so return 'Invalid'
+            return 'Invalid'
+
+        return numerator / math.sqrt((frac_c + frac_a))
 
     @property
     def confidence_level(self):

--- a/cleaver/tests/test_experiment.py
+++ b/cleaver/tests/test_experiment.py
@@ -99,12 +99,18 @@ class TestVariantStat(TestCase):
         # Variant A:       180	         45 	    1.33
         # Variant B:       189	         28 	    -1.13
         # Variant C:       188	         61 	    2.94
+        # Variant D:       188	        188 	    27.648
+        # Variant E:       188	        214 	    235.953
+        # Variant F:       188	        215 	    Invalid
         #
         map_ = {
             'x': (182, 35),
             'a': (180, 45),
             'b': (189, 28),
-            'c': (188, 61)
+            'c': (188, 61),
+            'd': (188, 188),
+            'e': (188, 214),
+            'f': (188, 215),
         }
         e = Mock()
         e.control = 'x'
@@ -123,6 +129,15 @@ class TestVariantStat(TestCase):
 
         v = VariantStat('c', e)
         assert round(v.z_score, 3) == 2.941
+
+        v = VariantStat('d', e)
+        assert round(v.z_score, 3) == 27.648
+
+        v = VariantStat('e', e)
+        assert round(v.z_score, 3) == 235.953
+
+        v = VariantStat('f', e)
+        assert v.z_score == "Invalid"
 
     @patch.object(VariantStat, 'z_score', 'N/A')
     def test_unknown_confidence(self):


### PR DESCRIPTION
in rare circumstances (when conversions greatly outnumber participants), a ValueError is raised when attempting to calculate a z-score. this makes the web interface unusable.

this code checks for invalid experiment data and returns 'Invalid' before attempting the final z-score calculation
