### PR TITLE
Allow different experiments to reuse variant names (Issue #11)

### DIFF
--- a/cleaver/backend/db/model.py
+++ b/cleaver/backend/db/model.py
@@ -38,9 +38,10 @@ class Experiment(ModelBase):
 
 class Variant(ModelBase):
     __tablename__ = 'cleaver_variant'
+    __table_args__ = (UniqueConstraint('name', 'experiment_id'),)
 
     id = sa.Column(sa.Integer, primary_key=True, autoincrement=True)
-    name = sa.Column(sa.Unicode(255), unique=True)
+    name = sa.Column(sa.Unicode(255))
     order = sa.Column(sa.Integer)
     experiment_id = sa.Column(
         sa.Integer,

--- a/cleaver/tests/backend/test_sqlalchemy.py
+++ b/cleaver/tests/backend/test_sqlalchemy.py
@@ -47,6 +47,17 @@ class TestSQLAlchemy(TestCase):
         assert experiment.variants[2].name == 'large'
         assert experiment.variants[2].experiment.name == 'text_size'
 
+    def test_save_multiple_experiments(self):
+        b = self.b
+        b.save_experiment('background_color', ('black', 'white', 'grey'))
+        b.save_experiment('foreground_color', ('black', 'white', 'grey'))
+
+        assert model.Experiment.query.count() == 2
+        first, second = model.Experiment.query.all()
+        assert first.name == 'background_color'
+        assert second.name == 'foreground_color'
+        assert set([v.name for v in first.variants]) == set([v.name for v in second.variants])
+
     def test_get_experiment_no_match(self):
         b = self.b
 


### PR DESCRIPTION
This change relaxes the schema such we can reuse variant names across
different experiments.

Since the new schema is strictly less restrictive, this change does not
break compatibility with existing cleaver DBs
